### PR TITLE
added SCA rule for incorrect syntax in arguments

### DIFF
--- a/src/rules/rhino-rules.json
+++ b/src/rules/rhino-rules.json
@@ -43,5 +43,21 @@
             "Plugin",
             "Test"
         ]
+    },
+    {
+        "type": "positive",
+        "description": "Unexpected character in arguments section.",
+        "expression": "(?<={{\\$)(?! +(`|--)|\\w).",
+        "id": "RHG0003",
+        "multiline": true,
+        "sections": [
+            "test-actions",
+            "test-expected-results"
+        ],
+        "severity": "error",
+        "entities": [
+            "Plugin",
+            "Test"
+        ]
     }
 ]


### PR DESCRIPTION
Rule is incomplete as single line functionality yet but finds most cases in which arguments syntax is written incorrectly.