### PR TITLE
Rhino multiline parsing for SCA

### DIFF
--- a/src/rules/rhino-rules.json
+++ b/src/rules/rhino-rules.json
@@ -46,7 +46,7 @@
     },
     {
         "type": "positive",
-        "description": "Unexpected character.",
+        "description": "Unexpected Character after '{{$' token: Missing argument name ' --%ArgumentName%' or macro name '%MacroName'.",
         "expression": "(?<={{\\$)(?![ \\t]+(`|--)|\\w).",
         "id": "RHG0003",
         "multiline": false,

--- a/src/rules/rhino-rules.json
+++ b/src/rules/rhino-rules.json
@@ -46,10 +46,10 @@
     },
     {
         "type": "positive",
-        "description": "Unexpected character in arguments section.",
-        "expression": "(?<={{\\$)(?! +(`|--)|\\w).",
+        "description": "Unexpected character.",
+        "expression": "(?<={{\\$)(?![ \\t]+(`|--)|\\w).",
         "id": "RHG0003",
-        "multiline": true,
+        "multiline": false,
         "sections": [
             "test-actions",
             "test-expected-results"

--- a/src/src/components/static-code-analyzer.ts
+++ b/src/src/components/static-code-analyzer.ts
@@ -5,6 +5,10 @@ import { Logger } from '../logging/logger';
 import { ExtensionLogger } from '../logging/extensions-logger';
 import { Channels } from '../constants/channels';
 import { TmLanguageCreateModel } from '../models/tm-create-model';
+import { DocumentData, FormattedRangeMap } from '../models/code-analysis-models';
+import { commentRegex, multilineRegex } from '../formatters/formatConstants';
+
+
 
 export class StaticCodeAnalyzer {
     private readonly _createModel: TmLanguageCreateModel | Promise<TmLanguageCreateModel>;
@@ -82,50 +86,126 @@ export class StaticCodeAnalyzer {
     private async newDiagnostics(diagnosticModel: DiagnosticModel, document: vscode.TextDocument): Promise<vscode.Diagnostic[]> {
         const diagnostics = diagnosticModel.multiline
             ? await this.resolveMultilineRule(diagnosticModel, document)
-            : this.resolveSinglelineRule(diagnosticModel, document);
+            : await this.resolveSinglelineRule(diagnosticModel, document);
 
         // get
         return diagnostics;
     }
 
-    // TODO: figure how to get range
-    private resolveSinglelineRule(diagnosticModel: DiagnosticModel, document: vscode.TextDocument): vscode.Diagnostic[] {
-        console.log(document);
-        console.log(diagnosticModel);
-        throw new Error();
-    }
+    private mergeRhinoMultilines(section: DocumentData): DocumentData{
+        let lines:string[] = [];
 
-    // TODO: optimize complexity
-    private async resolveMultilineRule(diagnosticModel: DiagnosticModel, document: vscode.TextDocument): Promise<vscode.Diagnostic[]> {
+        for(let sectionLine = 0; sectionLine < section.lines.length; sectionLine++){
+            let line = section.lines[sectionLine];
+            
+            let previousLineNumber = sectionLine - 1 < 0 ? 0 : sectionLine - 1;
+
+            let previousLine = section.lines[previousLineNumber];
+            let isMatch = line.trim().match(multilineRegex) !== null;
+
+            let isPreviousMatch = previousLine.trim().match(multilineRegex) !== null;
+            let isMultiline = isMatch && isPreviousMatch || (!isMatch && isPreviousMatch);
+
+            let formattedSectionLineNumber: number;
+            let endCharacterIndex: number;
+            if(isMultiline){
+                formattedSectionLineNumber = lines.length - 1;
+                let multiLine = lines[formattedSectionLineNumber];
+
+                line = " " + line.replace(multilineRegex, "");
+                multiLine = multiLine.replace(multilineRegex, "") + line;
+                lines[formattedSectionLineNumber] = multiLine;
+            }
+            else{
+                formattedSectionLineNumber = lines.length;
+                lines.push(line);
+            }
+            endCharacterIndex = lines[formattedSectionLineNumber].length;
+            let formattedRange: FormattedRangeMap = {
+                actualLine: sectionLine + section.range.start.line,
+                formattedPosition: new vscode.Position(formattedSectionLineNumber + section.range.start.line, endCharacterIndex)
+            };
+            if(!section?.formattedRange){
+                section.formattedRange = [];
+            }
+            section.formattedRange.push(formattedRange);
+        }
+        section.lines = lines;
+        return section;
+    }
+    // TODO: figure how to get range
+    private async resolveSinglelineRule(diagnosticModel: DiagnosticModel, document: vscode.TextDocument): Promise<vscode.Diagnostic[]> {
         // exit conditions
         if (!document) {
             return [];
         }
 
         // setup
-        const annotations = (await this._createModel).annotations;
         const diagnostics: vscode.Diagnostic[] = [];
-        const documentData = {
-            lines: document.getText().split(/\r?\n|\n\r?/),
-            range: this.getDocumentRange(document)
-        };
-        const sections = diagnosticModel.sections === undefined
-            ? [documentData]
-            : diagnosticModel.sections.map(i => this.getSection(documentData.lines, i, annotations));
+        const documentData = this.getDocumentData(document);
+        
+        const sections: DocumentData[] = await this.getDocumentSections(documentData, diagnosticModel.sections);
+        
+        // merge Rhino multilines
+        sections.forEach(section => section = this.mergeRhinoMultilines(section));
+        // {
+        //     let lines:string[] = [];
+
+        //     for(let sectionLine = 0; sectionLine < section.lines.length; sectionLine++){
+        //         let line = section.lines[sectionLine];
+                
+        //         let previousLineNumber = sectionLine - 1 < 0 ? 0 : sectionLine - 1;
+
+        //         let previousLine = section.lines[previousLineNumber];
+        //         let isMatch = line.trim().match(multilineRegex) !== null;
+
+        //         let isPreviousMatch = previousLine.trim().match(multilineRegex) !== null;
+        //         let isMultiline = isMatch && isPreviousMatch || (!isMatch && isPreviousMatch);
+
+        //         let formattedSectionLineNumber: number;
+        //         let endCharacterIndex: number;
+        //         if(isMultiline){
+        //             formattedSectionLineNumber = lines.length - 1;
+        //             let multiLine = lines[formattedSectionLineNumber];
+
+        //             line = " " + line.replace(multilineRegex, "");
+        //             multiLine = multiLine.replace(multilineRegex, "") + line;
+        //             lines[formattedSectionLineNumber] = multiLine;
+        //         }
+        //         else{
+        //             formattedSectionLineNumber = lines.length;
+        //             lines.push(line);
+        //         }
+        //         endCharacterIndex = lines[formattedSectionLineNumber].length;
+        //         let formattedRange: FormattedRangeMap = {
+        //             actualLine: sectionLine + section.range.start.line,
+        //             formattedPosition: new vscode.Position(formattedSectionLineNumber + section.range.start.line, endCharacterIndex)
+        //         };
+        //         if(!section?.formattedRange){
+        //             section.formattedRange = [];
+        //         }
+        //         section.formattedRange.push(formattedRange);
+        //     }
+        //     section.lines = lines;
+        // });
 
         // iterate
         sections.forEach(section => {
             for (let i = 0; i < section.lines.length; i++) {
                 const line = section.lines[i];
+                if(line.match(commentRegex)){
+                    continue;
+                }
                 const isNegative = diagnosticModel.type.toUpperCase() === 'NEGATIVE';
                 const isPositive = diagnosticModel.type.toUpperCase() === 'POSITIVE';
-
+                let formattedLineNumber = section.range.start.line + i;
+                let formattedRange = section.formattedRange?.filter(r => r.formattedPosition.line === formattedLineNumber);
                 if (isNegative) {
-                    let collection = this.assertNegative(diagnosticModel, section.range.start.line + i, line);
+                    let collection = this.assertNegative(diagnosticModel, formattedLineNumber, line, formattedRange);
                     diagnostics.push(...collection);
                 }
                 else if (isPositive) {
-                    let collection = this.assertPositive(diagnosticModel, section.range.start.line + i, line);
+                    let collection = this.assertPositive(diagnosticModel, formattedLineNumber, line, formattedRange);
                     diagnostics.push(...collection);
                 }
             }
@@ -135,47 +215,125 @@ export class StaticCodeAnalyzer {
         return diagnostics;
     }
 
-    private assertNegative(diagnosticModel: DiagnosticModel, lineNumber: number, line: string): vscode.Diagnostic[] {
+    private getDocumentData(document: vscode.TextDocument){
+        const documentData = {
+            lines: document.getText().split(/\r?\n|\n\r?/),
+            range: this.getDocumentRange(document),
+            formattedRange: []
+        };
+
+        return documentData;
+    }
+
+    private async getDocumentSections(documentData: DocumentData, sections: string[] | undefined): Promise<DocumentData[]>{
+        const annotations = (await this._createModel).annotations;
+        const documentSections: DocumentData[] = !sections
+            ? [documentData]
+            // flatMap to remove 'undefined' results
+            : sections.flatMap((section) => {
+                let doc = this.getSection(documentData.lines, section, annotations);
+                return doc ? doc : [];
+            });
+
+        return documentSections;
+    }
+    // TODO: optimize complexity
+    private async resolveMultilineRule(diagnosticModel: DiagnosticModel, document: vscode.TextDocument): Promise<vscode.Diagnostic[]> {
         // exit conditions
-        if (line.match(diagnosticModel.expression)) {
+        if (!document) {
             return [];
         }
 
         // setup
-        const start = new vscode.Position(lineNumber, 0);
-        const end = new vscode.Position(lineNumber, line.length);
-        const range = new vscode.Range(start, end);
-        const diagnostic = new vscode.Diagnostic(range, diagnosticModel.description, diagnosticModel.severity);
+        const diagnostics: vscode.Diagnostic[] = [];
+        const documentData = this.getDocumentData(document);
+        
+        const sections: DocumentData[] = await this.getDocumentSections(documentData, diagnosticModel.sections);
 
-        if(diagnosticModel.code){
-            diagnostic.code = {
-                target: vscode.Uri.parse(diagnosticModel.code.target),
-                value: diagnosticModel.code.value
-            };
-        }
+        // iterate
+        sections.forEach(section => {
+            for (let i = 0; i < section.lines.length; i++) {
+                const line = section.lines[i];
+                if(line.match(commentRegex)){
+                    continue;
+                }
+                const isNegative = diagnosticModel.type.toUpperCase() === 'NEGATIVE';
+                const isPositive = diagnosticModel.type.toUpperCase() === 'POSITIVE';
+                let formattedLineNumber = section.range.start.line + i;
+                let formattedRange = section.formattedRange?.filter(r => r.formattedPosition.line === formattedLineNumber);
+                if (isNegative) {
+                    let collection = this.assertNegative(diagnosticModel, formattedLineNumber, line, formattedRange);
+                    diagnostics.push(...collection);
+                }
+                else if (isPositive) {
+                    let collection = this.assertPositive(diagnosticModel, formattedLineNumber, line, formattedRange);
+                    diagnostics.push(...collection);
+                }
+            }
+        });
 
         // get
-        return [diagnostic];
+        return diagnostics;
     }
 
-    private assertPositive(diagnosticModel: DiagnosticModel, lineNumber: number, line: string) {
+    private assertNegative(diagnosticModel: DiagnosticModel, lineNumber: number, line: string, formattedRange: FormattedRangeMap[] | undefined): vscode.Diagnostic[] {
+        // exit conditions
+        
+        if (line.match(diagnosticModel.expression)) {
+            return [];
+        }
+        
+            let sortedRange = formattedRange && formattedRange.length > 1 ? formattedRange.sort((r1,r2) => r1.actualLine - r2.actualLine) : undefined;
+            let actualStartLine = sortedRange ? sortedRange[0].actualLine : lineNumber;
+            let actualEndLine = sortedRange ? sortedRange[sortedRange.length - 1].actualLine : lineNumber;
+            let actualEndCharacter = sortedRange ? sortedRange[sortedRange.length - 1].formattedPosition.character : line.length;
+    
+            // setup
+            const start = new vscode.Position(actualStartLine, 0);
+            const end = new vscode.Position(actualEndLine, actualEndCharacter);
+            const range = new vscode.Range(start, end);
+            const diagnostic = this.populateDiagnosticModel(range, diagnosticModel);
+        
+
+            // get
+            return [diagnostic];
+    }
+
+    private assertPositive(diagnosticModel: DiagnosticModel, lineNumber: number, line: string, formattedRange: FormattedRangeMap[] | undefined) {
         // setup
         const diagnostics: vscode.Diagnostic[] = [];
 
         // iterate
         let result;
         while (result = diagnosticModel.expression.exec(line)) {
-            const start = new vscode.Position(lineNumber, result.index);
-            const end = new vscode.Position(lineNumber, result.index + result[0].length);
-            const range = new vscode.Range(start, end);
-            const diagnostic = new vscode.Diagnostic(range, diagnosticModel.description, diagnosticModel.severity);
 
-            if(diagnosticModel.code!== null && diagnosticModel.code!==undefined){
-                diagnostic.code = {
-                    target: vscode.Uri.parse(diagnosticModel.code.target),
-                    value: diagnosticModel.code.value
-                };
+            let start = new vscode.Position(lineNumber, result.index);
+            let end = new vscode.Position(lineNumber, result.index + result[0].length);
+            if(formattedRange && formattedRange.length > 0){
+                if(formattedRange.length === 1){
+                    let actualLine = formattedRange[0].actualLine;
+                    let actualStartCharacter = result.index;
+                    let actualEndCharacter = result.index + result[0].length;
+
+                    start = new vscode.Position(actualLine, actualStartCharacter);
+                    end = new vscode.Position(actualLine, actualEndCharacter);    
+                }
+                let sortedRange = formattedRange.sort((r1,r2) => r1.actualLine - r2.actualLine);
+                for(let item of sortedRange){
+                    if(item.formattedPosition.character < result.index){
+                        let actualLine = item.actualLine;
+                        let actualStartCharacter = result.index - item.formattedPosition.character;
+                        let actualEndCharacter = actualStartCharacter + result[0].length;
+
+                        start = new vscode.Position(actualLine, actualStartCharacter);
+                        end = new vscode.Position(actualLine, actualEndCharacter);
+                        break;
+                    }
+                }
             }
+
+            const range = new vscode.Range(start, end);
+            const diagnostic = this.populateDiagnosticModel(range, diagnosticModel);
 
             diagnostics.push(diagnostic);
         }
@@ -184,6 +342,18 @@ export class StaticCodeAnalyzer {
         return diagnostics;
     }
 
+
+    private populateDiagnosticModel(range: vscode.Range, diagnosticModel: DiagnosticModel) {
+        const diagnostic = new vscode.Diagnostic(range, diagnosticModel.description, diagnosticModel.severity);
+
+        if (diagnosticModel?.code) {
+            diagnostic.code = {
+                target: vscode.Uri.parse(diagnosticModel.code.target),
+                value: diagnosticModel.code.value
+            };
+        }
+        return diagnostic;
+    }
 
     private getDocumentRange(document: vscode.TextDocument) {
         // setup
@@ -252,6 +422,7 @@ export class StaticCodeAnalyzer {
             model.description = entry.description;
             model.expression = new RegExp(entry.expression, 'g');
             model.id = entry.id;
+            model.multiline = entry?.multiline ? entry.multiline : false;
             model.sections = entry.sections;
             model.severity = StaticCodeAnalyzer.getSeverity(entry.severity);
             model.entities = entry.entities;
@@ -286,11 +457,11 @@ export class StaticCodeAnalyzer {
       │
       │ A collection of utility methods
       └────────────────────────────────────────────────────────*/
-    private getSection(document: string[], annotation: string, annotations: any[]): any {
+    private getSection(document: string[], annotation: string, annotations: any[]): DocumentData | undefined{
         try {
             // bad request
-            if (annotations === undefined || annotations === null || annotations.length === 0) {
-                return [];
+            if (!annotations) {
+                return;
             }
 
             // setup
@@ -325,7 +496,7 @@ export class StaticCodeAnalyzer {
             };
         } catch (error) {
             console.error(error);
-            return [];
+            return;
         }
     }
 }

--- a/src/src/extensions/utilities.ts
+++ b/src/src/extensions/utilities.ts
@@ -5,6 +5,7 @@ import { ServerConfiguration } from '../models/server-configuration';
 import { TreeItem } from '../components/tree-item';
 import { RhinoClient } from '../clients/rhino-client';
 import { TmLanguageCreateModel } from '../models/tm-create-model';
+import { multilineRegex } from '../formatters/formatConstants';
 
 export class Utilities {
     public static assertJson(str: string): boolean {
@@ -30,8 +31,6 @@ export class Utilities {
      * Summary. Normalize a test case document before sending it for invocation.
      */
     public static formatRhinoSpec(spec: String): string {
-        // constants
-        const multilineRegex = /\s`$/g;
 
         // setup
         const rawLines = spec.split('\n');

--- a/src/src/formatters/formatConstants.ts
+++ b/src/src/formatters/formatConstants.ts
@@ -1,0 +1,3 @@
+export const multilineRegex = /[^\S\r\n]+`$/g;
+export const fullLineCommentRegex = /^((\W+)?\d+\.?)?(\s+)?\/\*{2}/g;
+export const commentRegex = /(\s+)?\/\*\*.*/g;

--- a/src/src/formatters/test-case-formatter.ts
+++ b/src/src/formatters/test-case-formatter.ts
@@ -5,6 +5,7 @@
  */
 import * as vscode from 'vscode';
 import { Formatter } from "./formatter";
+import { commentRegex, multilineRegex } from './formatConstants';
 
 export class TestCaseFormatter extends Formatter {
     // members:
@@ -193,9 +194,8 @@ export class TestCaseFormatter extends Formatter {
 
     private getActions(testCase: string[], annotations: string[]): any {
         // setup
-        const commentRegex = /^((\W+)?\d+\.?)?(\s+)?\/\*{2}/g;
+        // const commentRegex = /^((\W+)?\d+\.?)?(\s+)?\/\*{2}/g;
         const indexRegex = /^((\s+)?(\d+(\.+)?))+(\s+)?/g;
-        const multilineRegex = /\s`$/g;
         let map: any[] = [];
 
         // build
@@ -209,11 +209,11 @@ export class TestCaseFormatter extends Formatter {
         // iterate
         let index = 1;
         for (let i = 1; i < actions.length; i++) {
-            const action = actions[i];
+            let action = actions[i];
 
-            let isComment = action.match(commentRegex) !== null;
+            let comment = action.match(commentRegex)?.[0];
+            // let isComment = comment !== null;
             let isEmpty = action === '';
-
             // multiline
             let previousLine = actions[(i - 1 < 0 ? 0 : i - 1)];
             let isMatch = action.trim().match(multilineRegex) !== null;
@@ -223,9 +223,14 @@ export class TestCaseFormatter extends Formatter {
             if (isEmpty) {
                 continue;
             }
-            if (isComment) {
-                map.push({ type: "comment", action: action, index: i });
-                continue;
+            if (comment) {
+                map.push({ type: "comment", action: comment, index: i });
+                if(comment === action){
+                    continue;
+                }
+                action = action.replace(comment,"");
+                
+                
             }
             if (isMultiline) {
                 map.push({ type: "multiline", action: action, index: i });
@@ -250,14 +255,14 @@ export class TestCaseFormatter extends Formatter {
 
     private getActionsCount(actions: any): number {
         // setup
-        const commentRegex = /^((\W+)?\d+\.?)?(\s+)?\/\*{2}/g;
-        const multilineRegex = /\s`$/g;
+        // const commentRegex = /^((\W+)?\d+\.?)?(\s+)?\/\*{2}/g;
         let counter = 0;
 
         // count
         for (let i = 1; i < actions.length; i++) {
             const action = actions[i];
-            let isComment = action.match(commentRegex) !== null;
+            let comment:string = action.match(commentRegex)?.[0];
+            let isComment = comment === action;
             let isEmpty = action === '';
 
             // multiline

--- a/src/src/models/code-analysis-models.ts
+++ b/src/src/models/code-analysis-models.ts
@@ -1,0 +1,12 @@
+import * as vscode from 'vscode';
+
+export type DocumentData = {
+    lines: string[];
+    range: vscode.Range;
+    formattedRange?: FormattedRangeMap[]
+};
+
+export type FormattedRangeMap = {
+    formattedPosition: vscode.Position;
+    actualLine: number;
+};

--- a/src/src/models/code-analysis-models.ts
+++ b/src/src/models/code-analysis-models.ts
@@ -3,10 +3,9 @@ import * as vscode from 'vscode';
 export type DocumentData = {
     lines: string[];
     range: vscode.Range;
-    formattedRange?: FormattedRangeMap[]
+    rhinoRange?: RhinoRangeMap[]
 };
-
-export type FormattedRangeMap = {
-    formattedPosition: vscode.Position;
+export type RhinoRangeMap = {
+    rhinoPosition: vscode.Position;
     actualLine: number;
 };

--- a/src/src/providers/provider-base.ts
+++ b/src/src/providers/provider-base.ts
@@ -9,6 +9,7 @@ import { Channels } from '../constants/channels';
 import { Utilities } from '../extensions/utilities';
 import { ExtensionLogger } from '../logging/extensions-logger';
 import { Logger } from '../logging/logger';
+import { multilineRegex } from '../formatters/formatConstants';
 
 export abstract class ProviderBase {
     // members: static
@@ -149,7 +150,6 @@ export abstract class ProviderBase {
 
     // TODO: breakout conditions
     public getMultilineContent(document: vscode.TextDocument, position: vscode.Position) {
-        const multilineRegex = /\s`$/g;
         let multiLine = document.lineAt(position).text;
         for (let i = document.lineAt(position).lineNumber - 1; i > 0 && document.lineAt(i).text.match(multilineRegex) !== null; i--) {
             multiLine = document.lineAt(i).text + multiLine;


### PR DESCRIPTION
Added functionality of merging rhino newlines ' `' to intended lines for static code analysis purposes.
Rhino newlines are merged when the 'multiline' argument of the rules JSON is undefined/false.